### PR TITLE
Update tokens.py

### DIFF
--- a/okta_oauth2/tokens.py
+++ b/okta_oauth2/tokens.py
@@ -107,7 +107,7 @@ class TokenValidator:
                 user.is_staff = True
                 user.is_superuser = True
                 user.save()
-            else:
+            elif self.config.superuser_group:
                 user.is_staff = False
                 user.is_superuser = False
                 user.save()

--- a/okta_oauth2/tokens.py
+++ b/okta_oauth2/tokens.py
@@ -99,20 +99,20 @@ class TokenValidator:
                     username=claims["email"], email=claims["email"]
                 )
 
-            if (
-                self.config.superuser_group
-                and "groups" in claims
-                and self.config.superuser_group in claims["groups"]
-            ):
-                user.is_staff = True
-                user.is_superuser = True
-                user.save()
-            elif self.config.superuser_group:
-                user.is_staff = False
-                user.is_superuser = False
-                user.save()
-
             if self.config.manage_groups:
+                if (
+                    self.config.superuser_group
+                    and "groups" in claims
+                    and self.config.superuser_group in claims["groups"]
+                ):
+                    user.is_staff = True
+                    user.is_superuser = True
+                    user.save()
+                elif "groups" in claims:
+                    user.is_staff = False
+                    user.is_superuser = False
+                    user.save()
+
                 self.manage_groups(user, claims["groups"])
 
         if "access_token" in token_result:


### PR DESCRIPTION
Updating user flags when a superuser_group is not set ends up wiping out admin users on first login. This change checks that superusers are being managed before wiping the permissions.