### PR TITLE
Only set Django User's staff/superuser on first login.

### DIFF
--- a/okta_oauth2/tokens.py
+++ b/okta_oauth2/tokens.py
@@ -99,18 +99,17 @@ class TokenValidator:
                     username=claims["email"], email=claims["email"]
                 )
 
-            if (
-                self.config.superuser_group
-                and "groups" in claims
-                and self.config.superuser_group in claims["groups"]
-            ):
-                user.is_staff = True
-                user.is_superuser = True
-                user.save()
-            else:
-                user.is_staff = False
-                user.is_superuser = False
-                user.save()
+                if (
+                    self.config.superuser_group
+                    and "groups" in claims
+                    and self.config.superuser_group in claims["groups"]
+                ):
+                    user.is_staff = True
+                    user.is_superuser = True
+                else:
+                    user.is_staff = False
+                    user.is_superuser = False
+            user.save()
 
             if self.config.manage_groups:
                 self.manage_groups(user, claims["groups"])


### PR DESCRIPTION
This pull request modifies the code such that the setting of superuser/staff status is only done on account creation.