### PR TITLE
Update pre commit

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install poetry
@@ -25,7 +25,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install poetry

--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -5,13 +5,13 @@ on: [push]
 jobs:
   style:
     name: Check code style
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install dependencies
         run: |
           python -m pip install poetry
@@ -22,10 +22,10 @@ jobs:
 
   build:
     name: Test and build python distribution
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -46,10 +46,10 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install dependencies
         run: |
           python -m pip install poetry

--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 .env
 poetry.lock
 .python-version
+.vscode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,14 +24,6 @@ repos:
       - id: isort
         name: isort (python)
         exclude: migrations\/[^/]*\.py$
-  # - repo: local
-  #   hooks:
-  #     - id: django-migrations
-  #       name: Django unmigrated changes
-  #       description: "This hook checks for unmigrated changes"
-  #       entry: sh -c "! poetry run parts makemigrations --dry-run --exit"
-  #       language: system
-  #       files: \.py$
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.4.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,44 +1,46 @@
-- repo: https://github.com/ambv/black
-  rev: stable
-  hooks:
-    - id: black
-      language_version: python3.8
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v1.2.3
-  hooks:
-    - id: check-added-large-files
-      args: ["--maxkb=1024"]
-    - id: check-case-conflict
-    - id: check-merge-conflict
-    - id: debug-statements
-    - id: end-of-file-fixer
-    - id: mixed-line-ending
-      args: ["--fix=lf"]
-    - id: trailing-whitespace
-    - id: requirements-txt-fixer
-    - id: flake8
-      exclude: migrations\/[^/]*\.py$|settings\.py$|vendor\/[^/]*\.*$|assets\/[^/]*\.*$
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.4
-  hooks:
-    - id: isort
-      exclude: migrations\/[^/]*\.py$
-- repo: local
-  hooks:
-    - id: django-migrations
-      name: Django unmigrated changes
-      description: "This hook checks for unmigrated changes"
-      entry: sh -c "! poetry run parts makemigrations --dry-run --exit"
-      language: system
-      files: \.py$
-- repo: https://github.com/Lucas-C/pre-commit-hooks
-  rev: v1.1.6
-  hooks:
-    - id: forbid-tabs
-      exclude: Makefile|\.bat$|vendor\/|assets\/
-- repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
-  rev: v1.0.4
-  hooks:
-    - id: python-bandit-vulnerability-check
-      args: [--recursive]
-      exclude: tests\/
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 23.1.0
+    hooks:
+      - id: black
+        language_version: python3.10
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+      - id: trailing-whitespace
+      - id: requirements-txt-fixer
+        exclude: migrations\/[^/]*\.py$|settings\.py$|vendor\/[^/]*\.*$|assets\/[^/]*\.*$
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort (python)
+        exclude: migrations\/[^/]*\.py$
+  # - repo: local
+  #   hooks:
+  #     - id: django-migrations
+  #       name: Django unmigrated changes
+  #       description: "This hook checks for unmigrated changes"
+  #       entry: sh -c "! poetry run parts makemigrations --dry-run --exit"
+  #       language: system
+  #       files: \.py$
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.4.2
+    hooks:
+      - id: forbid-tabs
+        exclude: Makefile|\.bat$|vendor\/|assets\/
+      - id: remove-tabs
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.5
+    hooks:
+    - id: bandit
+      args: ["-c", "pyproject.toml"]
+      additional_dependencies: ["bandit[toml]"]

--- a/okta_oauth2/conf.py
+++ b/okta_oauth2/conf.py
@@ -3,6 +3,7 @@ import re
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import NoReverseMatch, reverse
+from jwt.algorithms import get_default_algorithms
 
 # We can't check for tokens on these URL's
 # because we won't have them.
@@ -26,6 +27,10 @@ class Config:
             self.manage_groups = settings.OKTA_AUTH.get("MANAGE_GROUPS", False)
             # Timeout in seconds for requests to Okta
             self.request_timeout = settings.OKTA_AUTH.get("REQUEST_TIMEOUT", 10)
+            # Valid JWT decode algorithms (https://pyjwt.readthedocs.io/en/latest/algorithms.html)
+            self.jwt_algorithms = settings.OKTA_AUTH.get(
+                "JWT_ALGORITHMS", get_default_algorithms()
+            )
 
             # OpenID Specific
             self.client_id = settings.OKTA_AUTH["CLIENT_ID"]

--- a/okta_oauth2/conf.py
+++ b/okta_oauth2/conf.py
@@ -24,6 +24,8 @@ class Config:
             self.staff_group = settings.OKTA_AUTH.get("STAFF_GROUP", None)
             # Allow django-okta-auth to add groups
             self.manage_groups = settings.OKTA_AUTH.get("MANAGE_GROUPS", False)
+            # Timeout in seconds for requests to Okta
+            self.request_timeout = settings.OKTA_AUTH.get("REQUEST_TIMEOUT", 10)
 
             # OpenID Specific
             self.client_id = settings.OKTA_AUTH["CLIENT_ID"]

--- a/okta_oauth2/conf.py
+++ b/okta_oauth2/conf.py
@@ -27,10 +27,6 @@ class Config:
             self.manage_groups = settings.OKTA_AUTH.get("MANAGE_GROUPS", False)
             # Timeout in seconds for requests to Okta
             self.request_timeout = settings.OKTA_AUTH.get("REQUEST_TIMEOUT", 10)
-            # Valid JWT decode algorithms (https://pyjwt.readthedocs.io/en/latest/algorithms.html)
-            self.jwt_algorithms = settings.OKTA_AUTH.get(
-                "JWT_ALGORITHMS", get_default_algorithms()
-            )
 
             # OpenID Specific
             self.client_id = settings.OKTA_AUTH["CLIENT_ID"]

--- a/okta_oauth2/exceptions.py
+++ b/okta_oauth2/exceptions.py
@@ -3,7 +3,7 @@ class DjangoOktaAuthException(Exception):
 
 
 class InvalidToken(DjangoOktaAuthException):
-    """ Base exception for an invalid token """
+    """Base exception for an invalid token"""
 
     def __init__(self, message=None):
         if message:
@@ -13,43 +13,43 @@ class InvalidToken(DjangoOktaAuthException):
 
 
 class InvalidTokenSignature(InvalidToken):
-    """ Token signatures doesn't validate """
+    """Token signatures doesn't validate"""
 
     pass
 
 
 class IssuerDoesNotMatch(InvalidToken):
-    """ Token Issuer doesn't match expected issuer """
+    """Token Issuer doesn't match expected issuer"""
 
     pass
 
 
 class InvalidClientID(InvalidToken):
-    """ Token ClientID doesn't match expected Client ID """
+    """Token ClientID doesn't match expected Client ID"""
 
     pass
 
 
 class TokenExpired(InvalidToken):
-    """ Token expiration time is in the past """
+    """Token expiration time is in the past"""
 
     pass
 
 
 class TokenTooFarAway(InvalidToken):
-    """ The received token is not valid until too far in the future. """
+    """The received token is not valid until too far in the future."""
 
     pass
 
 
 class NonceDoesNotMatch(InvalidToken):
-    """ Token nonce does not match expected nonce """
+    """Token nonce does not match expected nonce"""
 
     pass
 
 
 class TokenRequestFailed(DjangoOktaAuthException):
-    """ The request to the token api endpoint has failed. """
+    """The request to the token api endpoint has failed."""
 
     pass
 

--- a/okta_oauth2/tests/settings.py
+++ b/okta_oauth2/tests/settings.py
@@ -55,3 +55,5 @@ TEMPLATES = [
         },
     },
 ]
+
+USE_TZ = True

--- a/okta_oauth2/tests/test_conf.py
+++ b/okta_oauth2/tests/test_conf.py
@@ -2,6 +2,7 @@ import re
 
 import pytest
 from django.core.exceptions import ImproperlyConfigured
+
 from okta_oauth2.conf import Config
 from okta_oauth2.tests.utils import update_okta_settings
 

--- a/okta_oauth2/tests/test_decorator.py
+++ b/okta_oauth2/tests/test_decorator.py
@@ -2,11 +2,12 @@ from unittest.mock import Mock, patch
 
 import pytest
 from django.test import Client
+
 from okta_oauth2.tests.utils import build_id_token
 
 
 def test_decorator_prevents_unauthenticated_access(client: Client):
-    """ If we're not authenticated we should return a redirect to the login """
+    """If we're not authenticated we should return a redirect to the login"""
     response = client.get("/decorated/")
     assert response.status_code == 302
     assert response.url == "/accounts/login/"
@@ -33,7 +34,7 @@ def test_decorator_allows_access_to_valid_token(client: Client):
 
 @pytest.mark.django_db
 def test_decorator_disallows_access_to_invalid_token(client: Client):
-    """ When an invalid token is supplied the decorator should reject. """
+    """When an invalid token is supplied the decorator should reject."""
     nonce = "123456"
     token = "notvalid"
 

--- a/okta_oauth2/tests/test_decorator.py
+++ b/okta_oauth2/tests/test_decorator.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 from django.test import Client
 
-from okta_oauth2.tests.utils import build_id_token
+from okta_oauth2.tests.utils import TEST_PUBLIC_KEY, build_id_token
 
 
 def test_decorator_prevents_unauthenticated_access(client: Client):
@@ -27,7 +27,9 @@ def test_decorator_allows_access_to_valid_token(client: Client):
     session["tokens"] = {"id_token": token}
     session.save()
 
-    with patch("okta_oauth2.tokens.TokenValidator._jwks", Mock(return_value="secret")):
+    with patch(
+        "okta_oauth2.tokens.TokenValidator._jwks", Mock(return_value=TEST_PUBLIC_KEY)
+    ):
         response = client.get("/decorated/")
         assert response.status_code == 200
 

--- a/okta_oauth2/tests/test_middleware.py
+++ b/okta_oauth2/tests/test_middleware.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 from django.http import HttpResponse
 from django.urls import reverse
+
 from okta_oauth2.exceptions import TokenExpired
 from okta_oauth2.middleware import OktaMiddleware
 from okta_oauth2.tests.utils import build_id_token, update_okta_settings
@@ -64,7 +65,6 @@ def test_token_expired_triggers_refresh(rf):
     with patch(
         "okta_oauth2.tokens.TokenValidator.validate_token", raises_token_expired
     ), patch("okta_oauth2.tokens.TokenValidator.tokens_from_refresh_token"):
-
         request = rf.get("/")
         request.COOKIES["okta-oauth-nonce"] = "123456"
         request.session = {
@@ -91,7 +91,6 @@ def test_token_expired_triggers_refresh_with_no_refresh(rf):
     with patch(
         "okta_oauth2.tokens.TokenValidator.validate_token", raises_token_expired
     ), patch("okta_oauth2.tokens.TokenValidator.tokens_from_refresh_token"):
-
         request = rf.get("/")
         request.COOKIES["okta-oauth-nonce"] = "123456"
         request.session = {"tokens": {"id_token": "imanexpiredtoken"}}

--- a/okta_oauth2/tests/test_middleware.py
+++ b/okta_oauth2/tests/test_middleware.py
@@ -5,7 +5,11 @@ from django.urls import reverse
 
 from okta_oauth2.exceptions import TokenExpired
 from okta_oauth2.middleware import OktaMiddleware
-from okta_oauth2.tests.utils import build_id_token, update_okta_settings
+from okta_oauth2.tests.utils import (
+    TEST_PUBLIC_KEY,
+    build_id_token,
+    update_okta_settings,
+)
 
 
 def test_no_token_redirects_to_login(rf):
@@ -45,7 +49,9 @@ def test_valid_token_returns_response(rf):
     # We're building a token here that we know will be valid
     token = build_id_token(nonce=nonce)
 
-    with patch("okta_oauth2.tokens.TokenValidator._jwks", Mock(return_value="secret")):
+    with patch(
+        "okta_oauth2.tokens.TokenValidator._jwks", Mock(return_value=TEST_PUBLIC_KEY)
+    ):
         request = rf.get("/")
         request.COOKIES["okta-oauth-nonce"] = nonce
         request.session = {"tokens": {"id_token": token}}

--- a/okta_oauth2/tests/test_token_validator.py
+++ b/okta_oauth2/tests/test_token_validator.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import Group
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.cache import caches
 from django.utils.timezone import now
+
 from okta_oauth2.conf import Config
 from okta_oauth2.exceptions import (
     InvalidClientID,
@@ -256,7 +257,7 @@ def test_jwks_sets_cache_and_returns(rf):
 
 @patch("okta_oauth2.tokens.requests.get")
 def test_request_jwks(mock_get, rf):
-    """ Test jwks method returns json """
+    """Test jwks method returns json"""
     mock_get.return_value = Mock(ok=True)
     mock_get.return_value.json.return_value = mock_request_jwks(None)
 
@@ -269,7 +270,7 @@ def test_request_jwks(mock_get, rf):
 
 
 def test_jwks_returns_if_none_found(rf):
-    """ The _jwks method should return None if no key is found. """
+    """The _jwks method should return None if no key is found."""
     c = Config()
 
     with patch(
@@ -280,7 +281,7 @@ def test_jwks_returns_if_none_found(rf):
 
 
 def test_validate_token_successfully_validates(rf):
-    """ A valid token should return the decoded token. """
+    """A valid token should return the decoded token."""
     token = build_id_token()
     c = Config()
     with patch("okta_oauth2.tokens.TokenValidator._jwks", Mock(return_value="secret")):

--- a/okta_oauth2/tests/test_token_validator.py
+++ b/okta_oauth2/tests/test_token_validator.py
@@ -27,7 +27,7 @@ SUPERUSER_GROUP = "Superusers"
 STAFF_GROUP = "Staff"
 
 KEY_1 = {
-    "alg": "RS256",
+    "alg": "HS256",
     "e": "AQAB",
     "n": """iKqiD4cr7FZKm6f05K4r-GQOvjRqjOeFmOho9V7SAXYwCyJluaGBLVvDWO1XlduPLOrsG_Wgs67SOG5qeLPR8T1zDK4bfJAo1Tvbw
             YeTwVSfd_0mzRq8WaVc_2JtEK7J-4Z0MdVm_dJmcMHVfDziCRohSZthN__WM2NwGnbewWnla0wpEsU3QMZ05_OxvbBdQZaDUsNSx4
@@ -39,7 +39,7 @@ KEY_1 = {
 }
 
 KEY_2 = {
-    "alg": "RS256",
+    "alg": "HS256",
     "e": "AQAB",
     "n": """l1hZ_g2sgBE3oHvu34T-5XP18FYJWgtul_nRNg-5xra5ySkaXEOJUDRERUG0HrR42uqf9jYrUTwg9fp-SqqNIdHRaN8EwRSDRsKAwK
             3HIJ2NJfgmrrO2ABkeyUq6rzHxAumiKv1iLFpSawSIiTEBJERtUCDcjbbqyHVFuivIFgH8L37-XDIDb0XG-R8DOoOHLJPTpsgH-rJe
@@ -98,7 +98,7 @@ def test_discovery_document_sets_json(mock_get):
     mock_get.return_value = Mock(ok=True)
     mock_get.return_value.json.return_value = {"key": "value"}
 
-    d = DiscoveryDocument("http://notreal.example.com")
+    d = DiscoveryDocument(Config())
     assert d.getJson() == {"key": "value"}
 
 

--- a/okta_oauth2/tests/urls.py
+++ b/okta_oauth2/tests/urls.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponse
 from django.urls import include, path
+
 from okta_oauth2.decorators import okta_login_required
 
 

--- a/okta_oauth2/tests/utils.py
+++ b/okta_oauth2/tests/utils.py
@@ -1,5 +1,6 @@
 from django.utils.timezone import now
 from jose import jwt
+
 from okta_oauth2.conf import Config
 
 

--- a/okta_oauth2/tests/utils.py
+++ b/okta_oauth2/tests/utils.py
@@ -3,6 +3,33 @@ from jose import jwt
 
 from okta_oauth2.conf import Config
 
+TEST_PRIVATE_KEY = """
+-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQC3UnFAPMb32q3IcBTbG46qLamnh0CbqPwEQKn9wrzBFhJ3nhtB
+FQStNI8TXUPLN87i7hZt8tX4iWkUYJskwz98qZj8vc7LhT6/MBulyLyMP2VYva2D
+ufezz5qX6n/xBo6bgv1XsTyS4EdBN9QL2oc23bu7MUoDsor0tNGuy5xKjQIDAQAB
+AoGBAJ1qAmtJhQSBV2Zcr9vxTtDcguii4ByJv1WbfRy0okYewN7L+dUpyik8j3ru
+Q+91TYZZMRNaSNewjnV7+txXd+QM5mLorfmYEIuvxVf6edXgzRuNfol1UO0gjWl3
+wpoNUQXHqSp7f2pluLw/wTFAgFOWTMmE4tdFe4KCImmkljW1AkEA2Saus/usqA4r
+QfroAdLn2dKR6kO2LXdORpaNZ1NgXw4+nqDMYNBPilOUh5L+fq8VzNF0o50PfO83
+u74oknT4twJBANgea6Xp37V2QLnU2G98DGd9E24EqvQkRopDq0kYdXzNpsVLx7fu
+76QXSPO4OqxzlIq3HguWlK+oKEBOZ3iuqtsCQQDNaj07Puk99GFRQfM0vnjaYcns
+LG9qJQDj30kWJBX29XehAQU00/laJeRMN24NErzxinXmzA05puU28RRaLtKTAkAi
+5H5y0hipPodiuWecUEXca4g4ig5jznuJFTXRXl6RoM5dKkf7fVs5ffzsRIFMmHiS
+ENCMBGrLFXYyM7Zm+KRjAkAJFILd+qtdADilYbyf4KPU766TT1dtljAoTBzxZ0T9
+2VblbIa1tmvs35apo6fxFf4dXOZNiz85OMFvxglvmIus
+-----END RSA PRIVATE KEY-----
+"""
+
+TEST_PUBLIC_KEY = """
+-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC3UnFAPMb32q3IcBTbG46qLamn
+h0CbqPwEQKn9wrzBFhJ3nhtBFQStNI8TXUPLN87i7hZt8tX4iWkUYJskwz98qZj8
+vc7LhT6/MBulyLyMP2VYva2Dufezz5qX6n/xBo6bgv1XsTyS4EdBN9QL2oc23bu7
+MUoDsor0tNGuy5xKjQIDAQAB
+-----END PUBLIC KEY-----
+"""
+
 
 def update_okta_settings(okta_settings, k, v):
     """
@@ -51,7 +78,7 @@ def build_id_token(
 
     headers = {"kid": "1A234567890"}
 
-    return jwt.encode(claims, "secret", headers=headers, algorithm="HS256")
+    return jwt.encode(claims, TEST_PRIVATE_KEY, headers=headers, algorithm="RS256")
 
 
 def build_access_token(
@@ -62,7 +89,7 @@ def build_access_token(
     current_timestamp = now().timestamp()
     iat_offset = 2
 
-    headers = {"alg": "HS256", "kid": "abcdefg"}
+    headers = {"alg": "RS256", "kid": "abcdefg"}
 
     claims = {
         "ver": 1,
@@ -76,4 +103,4 @@ def build_access_token(
         "scp": ["openid", "email", "offline_access", "groups"],
     }
 
-    return jwt.encode(claims, "secret", headers=headers, algorithm="HS256")
+    return jwt.encode(claims, TEST_PRIVATE_KEY, headers=headers, algorithm="RS256")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ python-jose = {version = "^3.1.0", extras = ["cryptography"]}
 [tool.poetry.dev-dependencies]
 pre-commit = "^3.1.1"
 rope = "^0.16.0"
-pytest = "^5.3.5"
-pytest-django = "^3.8.0"
+pytest = "^7.2"
+pytest-django = "^4.5"
 mypy = "^1.1"
 black = {version = "^23.1.0", allow-prereleases = true}
 flake8 = "^3.8.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,20 +12,23 @@ homepage = "https://github.com/AzMoo/django-okta-auth"
 repository = "https://github.com/AzMoo/django-okta-auth"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.8"
 Django = ">=1.11.0"
 requests = "^2.22.0"
-PyJWT = "^2.*"
+PyJWT = "^2"
 python-jose = {version = "^3.1.0", extras = ["cryptography"]}
 
 [tool.poetry.dev-dependencies]
-pre-commit = "^2.0.1"
+pre-commit = "^3.1.1"
 rope = "^0.16.0"
 pytest = "^5.3.5"
 pytest-django = "^3.8.0"
-mypy = "^0.782"
-black = {version = "^20.8b1", allow-prereleases = true}
+mypy = "^1.1"
+black = {version = "^23.1.0", allow-prereleases = true}
 flake8 = "^3.8.4"
+
+[tool.bandit]
+exclude_dirs = ["tests"]
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Update pre-commit to latest version 3.1.1, and new versions of pre-commit tools. This also led to updates of dev dependencies to keep the environment aligned with pre-commit. 

Updated PyJWT to support any minor version of major version 2.

Add a timeout to requests made by the requests library to Okta. Defaults to 10s but added a new setting to allow it to be configured.

Minor style improvements across everything.

Update test mocks to return proper certificates to testing properly validates JWTs. 